### PR TITLE
fix: log for own browser env var issues

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -172,18 +172,14 @@ async def run_custom_agent(
             chrome_exe = os.getenv("CHROME_PATH", "")
             chrome_use_data = os.getenv("CHROME_USER_DATA", "")
 
-            if not chrome_exe:
-                raise ValueError("You selected use own browser, but CHROME_PATH environment variable is not set. Please set it to your Chrome executable path.")
-            
-            if not os.path.exists(chrome_exe):
+            if chrome_exe == "":
+                chrome_exe = None
+            elif not os.path.exists(chrome_exe):
                 raise ValueError(f"Chrome executable not found at {chrome_exe}")
             
-            if not chrome_use_data:
-                raise ValueError("You selected use own browser, but CHROME_USER_DATA environment variable is not set. Please set it to your Chrome user data directory.")
-            
-            if not os.path.exists(os.path.expanduser(chrome_use_data)):
-                raise ValueError(f"Chrome user data directory not found at {chrome_use_data}")
-            
+            if chrome_use_data == "":
+                chrome_use_data = None
+
             browser_context_ = await playwright.chromium.launch_persistent_context(
                 user_data_dir=chrome_use_data,
                 executable_path=chrome_exe,

--- a/webui.py
+++ b/webui.py
@@ -171,6 +171,18 @@ async def run_custom_agent(
             playwright = await async_playwright().start()
             chrome_exe = os.getenv("CHROME_PATH", "")
             chrome_use_data = os.getenv("CHROME_USER_DATA", "")
+
+            if not chrome_exe:
+                raise ValueError("You selected use own browser, but CHROME_PATH environment variable is not set. Please set it to your Chrome executable path.")
+            
+            if not os.path.exists(chrome_exe):
+                raise ValueError(f"Chrome executable not found at {chrome_exe}")
+            if not chrome_use_data:
+                raise ValueError("You selected use own browser, but CHROME_USER_DATA environment variable is not set. Please set it to your Chrome user data directory.")
+            
+            if not os.path.exists(os.path.expanduser(chrome_use_data)):
+                raise ValueError(f"Chrome user data directory not found at {chrome_use_data}")
+            
             browser_context_ = await playwright.chromium.launch_persistent_context(
                 user_data_dir=chrome_use_data,
                 executable_path=chrome_exe,

--- a/webui.py
+++ b/webui.py
@@ -177,6 +177,7 @@ async def run_custom_agent(
             
             if not os.path.exists(chrome_exe):
                 raise ValueError(f"Chrome executable not found at {chrome_exe}")
+            
             if not chrome_use_data:
                 raise ValueError("You selected use own browser, but CHROME_USER_DATA environment variable is not set. Please set it to your Chrome user data directory.")
             


### PR DESCRIPTION
Add logs in case user selected on browser but either forgot to add the right env vars (CHROME_PATH, CHROME_USER_DATA) or set them to incorrect paths