### PR TITLE
feat: add llm provider and model default value to supperss `UserWarning`

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -382,12 +382,13 @@ def create_ui(theme_name="Ocean"):
                     llm_provider = gr.Dropdown(
                         ["anthropic", "openai", "deepseek", "gemini", "ollama", "azure_openai"],
                         label="LLM Provider",
-                        value="deepseek",
+                        value="openai",
                         info="Select your preferred language model provider"
                     )
                     llm_model_name = gr.Dropdown(
                         label="Model Name",
-                        value="deepseek-chat",
+                        choices=["gpt-4o", "gpt-4o-mini", "gpt-4", "gpt-3.5-turbo",],
+                        value="gpt-4o",
                         interactive=True,
                         allow_custom_value=True,  # Allow users to input custom model names
                         info="Select a model from the dropdown or type a custom model name"

--- a/webui.py
+++ b/webui.py
@@ -382,12 +382,12 @@ def create_ui(theme_name="Ocean"):
                     llm_provider = gr.Dropdown(
                         ["anthropic", "openai", "deepseek", "gemini", "ollama", "azure_openai"],
                         label="LLM Provider",
-                        value="",
+                        value="deepseek",
                         info="Select your preferred language model provider"
                     )
                     llm_model_name = gr.Dropdown(
                         label="Model Name",
-                        value="",
+                        value="deepseek-chat",
                         interactive=True,
                         allow_custom_value=True,  # Allow users to input custom model names
                         info="Select a model from the dropdown or type a custom model name"


### PR DESCRIPTION
To suppress the below `UserWarning`, we can set a default value for `LLM Provider` and `LLM Model Name`. The `warning` was as below:

```
H:\Documents\Work\browser-web-ui\myenv\Lib\site-packages\gradio\components\dropdown.py:226: UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include:  or set allow_custom_value=True.
```