### PR TITLE
Feature/save agent history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,9 @@ AgentHistory.json
 cv_04_24.pdf
 AgentHistoryList.json
 *.gif
+
+# For Sharing (.pem files)
+.gradio/
+
+# For Docker
+data/

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -200,3 +200,11 @@ async def capture_screenshot(browser_context):
         return encoded
     except Exception as e:
         return None
+
+def download_agent_history(save_agent_history_path):
+    history_file = os.path.join(save_agent_history_path, "AgentHistory.json")
+    history_file = os.path.abspath(history_file)  # Convert to absolute path
+    if os.path.exists(history_file):
+        return history_file
+    else:
+        return None

--- a/webui.py
+++ b/webui.py
@@ -92,6 +92,7 @@ async def run_browser_agent(
         window_w,
         window_h,
         save_recording_path,
+        save_agent_history_path,
         save_trace_path,
         enable_recording,
         task,
@@ -156,6 +157,7 @@ async def run_browser_agent(
                 window_w=window_w,
                 window_h=window_h,
                 save_recording_path=save_recording_path,
+                save_agent_history_path=save_agent_history_path,
                 save_trace_path=save_trace_path,
                 task=task,
                 add_infos=add_infos,
@@ -299,6 +301,7 @@ async def run_custom_agent(
         window_w,
         window_h,
         save_recording_path,
+        save_agent_history_path,
         save_trace_path,
         task,
         add_infos,
@@ -361,6 +364,9 @@ async def run_custom_agent(
         )
         history = await agent.run(max_steps=max_steps)
 
+        history_file = os.path.join(save_agent_history_path, "AgentHistory.json")
+        agent.save_history(history_file)
+
         final_result = history.final_result()
         errors = history.errors()
         model_actions = history.model_actions()
@@ -399,6 +405,7 @@ async def run_with_stream(
     window_w,
     window_h,
     save_recording_path,
+    save_agent_history_path,
     save_trace_path,
     enable_recording,
     task,
@@ -425,6 +432,7 @@ async def run_with_stream(
             window_w=window_w,
             window_h=window_h,
             save_recording_path=save_recording_path,
+            save_agent_history_path=save_agent_history_path,
             save_trace_path=save_trace_path,
             enable_recording=enable_recording,
             task=task,
@@ -455,6 +463,7 @@ async def run_with_stream(
                     window_w=window_w,
                     window_h=window_h,
                     save_recording_path=save_recording_path,
+                    save_agent_history_path=save_agent_history_path,
                     save_trace_path=save_trace_path,
                     enable_recording=enable_recording,
                     task=task,
@@ -725,6 +734,14 @@ def create_ui(theme_name="Ocean"):
                         interactive=True,
                     )
 
+                    save_agent_history_path = gr.Textbox(
+                        label="Agent History Save Path",
+                        placeholder="e.g., ./tmp/agent_history",
+                        value="./tmp/agent_history",
+                        info="Specify the directory where agent history should be saved.",
+                        interactive=True,
+                    )
+
             with gr.TabItem("🤖 Run Agent", id=4):
                 task = gr.Textbox(
                     label="Task Description",
@@ -777,6 +794,14 @@ def create_ui(theme_name="Ocean"):
 
                     trace_file = gr.File(label="Trace File")
 
+                    history_download_button = gr.Button("⬇️ Download Agent History")
+
+                    history_download_button.click(
+                        fn=utils.download_agent_history,
+                        inputs=save_agent_history_path,
+                        outputs=gr.File(),
+                    )
+
                 # Bind the stop button click event after errors_output is defined
                 stop_button.click(
                     fn=stop_agent,
@@ -787,11 +812,12 @@ def create_ui(theme_name="Ocean"):
                 # Run button click handler
                 run_button.click(
                     fn=run_with_stream,
-                    inputs=[
-                        agent_type, llm_provider, llm_model_name, llm_temperature, llm_base_url, llm_api_key,
-                        use_own_browser, keep_browser_open, headless, disable_security, window_w, window_h, save_recording_path, save_trace_path,
-                        enable_recording, task, add_infos, max_steps, use_vision, max_actions_per_step, tool_call_in_content
-                    ],
+                        inputs=[
+                            agent_type, llm_provider, llm_model_name, llm_temperature, llm_base_url, llm_api_key,
+                            use_own_browser, keep_browser_open, headless, disable_security, window_w, window_h,
+                            save_recording_path, save_agent_history_path, save_trace_path,  # Include the new path
+                            enable_recording, task, add_infos, max_steps, use_vision, max_actions_per_step, tool_call_in_content
+                        ],
                     outputs=[
                         browser_view,           # Browser view
                         final_result_output,    # Final result


### PR DESCRIPTION
Saveing agent history is now available. You can set the `AgentHistory` path in `Browser Settings`, and then you can download the file in `Results` as an `AgentHistory.json` file which consist of the history of the agent.

Sample Agent History Path:
![Screenshot 2025-01-13 202533](https://github.com/user-attachments/assets/6af3ad0b-31cf-428d-89b5-fae67dee10f3)


Sample output box in `Results`:
![Screenshot 2025-01-13 215334](https://github.com/user-attachments/assets/d94dd1dc-4740-4aa0-84e2-fb8cf434ad10)
