### PR TITLE
Chore/recording path disappear if toggled

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -165,6 +165,8 @@ def get_latest_files(directory: str, file_types: list = ['.webm', '.zip']) -> Di
             print(f"Error getting latest {file_type} file: {e}")
             
     return latest_files
+
+
 async def capture_screenshot(browser_context):
     """Capture and encode a screenshot"""
     # Extract the Playwright browser instance
@@ -201,3 +203,11 @@ async def capture_screenshot(browser_context):
         return encoded
     except Exception as e:
         return None
+
+
+def toggle_textbox(show):
+    """Toggle the visibility of the textbox based on checkbox state."""
+    if show:
+        return gr.update(visible=True)  # Show the textbox
+    else:
+        return gr.update(visible=False)  # Hide the textbox

--- a/webui.py
+++ b/webui.py
@@ -40,7 +40,7 @@ from src.browser.custom_context import BrowserContextConfig, CustomBrowserContex
 from src.controller.custom_controller import CustomController
 from gradio.themes import Citrus, Default, Glass, Monochrome, Ocean, Origin, Soft, Base
 from src.utils.default_config_settings import default_config, load_config_from_file, save_config_to_file, save_current_config, update_ui_from_config
-from src.utils.utils import update_model_dropdown, get_latest_files, capture_screenshot
+from src.utils.utils import toggle_textbox, update_model_dropdown, get_latest_files, capture_screenshot
 
 from dotenv import load_dotenv
 load_dotenv()
@@ -766,6 +766,8 @@ def create_ui(config, theme_name="Ocean"):
                         info="Specify the directory where agent history should be saved.",
                         interactive=True,
                     )
+
+                    enable_recording.change(fn=toggle_textbox, inputs=enable_recording, outputs=save_recording_path)
 
             with gr.TabItem("🤖 Run Agent", id=4):
                 task = gr.Textbox(


### PR DESCRIPTION
When `Enable Recording` is toggled, based on its value, the `Recording Path` can be `visible` or `invisible` in the UI.