### PR TITLE
fix: set architecture explicitly in docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.11-slim
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     wget \
+    netcat-traditional \
     gnupg \
     curl \
     unzip \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   browser-use-webui:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
**Issue:** 
on non amd64 architectures google chrome will not install.

**Details:**
From running dockerfile:
```
RUN apt-get install -y google-chrome-stable

Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package google-chrome-stable
```

**Solution:**
Set docker architecture explicitly ensures google-chrome is available to install.

Note: also added netcat as it was missing to let the health check pass.