### PR TITLE
Update utils.py to support ollama GPU usage

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -107,6 +107,7 @@ def get_llm_model(provider: str, **kwargs):
                 temperature=kwargs.get("temperature", 0.0),
                 num_ctx=kwargs.get("num_ctx", 32000),
                 num_predict=kwargs.get("num_predict", 1024),
+                num_gpu=1,  # Explicitly enable GPU usage
                 base_url=kwargs.get("base_url", base_url),
             )
     elif provider == "azure_openai":


### PR DESCRIPTION
When using the code prior to this patch ollama only uses CPU.  With this patch ollama will use all of the GPU available and then fallback to using CPU (RAM).