### PR TITLE
refactor: use modern typing syntax

### DIFF
--- a/src/agent/custom_agent.py
+++ b/src/agent/custom_agent.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pdb
 import traceback
-from typing import Optional, Type, List, Dict, Any, Callable
+from typing import Any, Callable
 from PIL import Image, ImageDraw, ImageFont
 import os
 import base64
@@ -50,11 +50,11 @@ class CustomAgent(Agent):
             browser_context: BrowserContext | None = None,
             controller: Controller = Controller(),
             use_vision: bool = True,
-            save_conversation_path: Optional[str] = None,
+            save_conversation_path: str | None = None,
             max_failures: int = 5,
             retry_delay: int = 10,
-            system_prompt_class: Type[SystemPrompt] = SystemPrompt,
-            agent_prompt_class: Type[AgentMessagePrompt] = AgentMessagePrompt,
+            system_prompt_class: type[SystemPrompt] = SystemPrompt,
+            agent_prompt_class: type[AgentMessagePrompt] = AgentMessagePrompt,
             max_input_tokens: int = 128000,
             validate_output: bool = False,
             include_attributes: list[str] = [
@@ -73,11 +73,11 @@ class CustomAgent(Agent):
             max_actions_per_step: int = 10,
             tool_call_in_content: bool = True,
             agent_state: AgentState = None,
-            initial_actions: Optional[List[Dict[str, Dict[str, Any]]]] = None,
+            initial_actions: list[dict[str, dict[str, Any]]] | None = None,
             # Cloud Callbacks
             register_new_step_callback: Callable[['BrowserState', 'AgentOutput', int], None] | None = None,
             register_done_callback: Callable[['AgentHistoryList'], None] | None = None,
-            tool_calling_method: Optional[str] = 'auto',
+            tool_calling_method: str | None = 'auto',
     ):
         super().__init__(
             task=task,
@@ -220,7 +220,7 @@ class CustomAgent(Agent):
         return parsed
 
     @time_execution_async("--step")
-    async def step(self, step_info: Optional[CustomAgentStepInfo] = None) -> None:
+    async def step(self, step_info: CustomAgentStepInfo | None = None) -> None:
         """Execute one step of the task"""
         logger.info(f"\n📍 Step {self.n_steps}")
         state = None

--- a/src/agent/custom_massage_manager.py
+++ b/src/agent/custom_massage_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Optional, Type
 
 from browser_use.agent.message_manager.service import MessageManager
 from browser_use.agent.message_manager.views import MessageHistory
@@ -30,15 +29,15 @@ class CustomMassageManager(MessageManager):
             llm: BaseChatModel,
             task: str,
             action_descriptions: str,
-            system_prompt_class: Type[SystemPrompt],
-            agent_prompt_class: Type[AgentMessagePrompt],
+            system_prompt_class: type[SystemPrompt],
+            agent_prompt_class: type[AgentMessagePrompt],
             max_input_tokens: int = 128000,
             estimated_characters_per_token: int = 3,
             image_tokens: int = 800,
             include_attributes: list[str] = [],
             max_error_length: int = 400,
             max_actions_per_step: int = 10,
-            message_context: Optional[str] = None
+            message_context: str | None = None
     ):
         super().__init__(
             llm=llm,
@@ -74,9 +73,9 @@ class CustomMassageManager(MessageManager):
     def add_state_message(
             self,
             state: BrowserState,
-            actions: Optional[List[ActionModel]] = None,
-            result: Optional[List[ActionResult]] = None,
-            step_info: Optional[AgentStepInfo] = None,
+            actions: list[ActionModel] | None = None,
+            result: list[ActionResult] | None = None,
+            step_info: AgentStepInfo | None = None,
     ) -> None:
         """Add browser state as human message"""
         # otherwise add state message and result to next message (which will not stay in memory)

--- a/src/agent/custom_prompts.py
+++ b/src/agent/custom_prompts.py
@@ -1,5 +1,4 @@
 import pdb
-from typing import List, Optional
 
 from browser_use.agent.prompts import SystemPrompt, AgentMessagePrompt
 from browser_use.agent.views import ActionResult, ActionModel
@@ -140,11 +139,11 @@ class CustomAgentMessagePrompt(AgentMessagePrompt):
     def __init__(
             self,
             state: BrowserState,
-            actions: Optional[List[ActionModel]] = None,
-            result: Optional[List[ActionResult]] = None,
+            actions: list[ActionModel] | None = None,
+            result: list[ActionResult] | None = None,
             include_attributes: list[str] = [],
             max_error_length: int = 400,
-            step_info: Optional[CustomAgentStepInfo] = None,
+            step_info: CustomAgentStepInfo | None = None,
     ):
         super(CustomAgentMessagePrompt, self).__init__(state=state, 
                                                        result=result, 

--- a/src/agent/custom_views.py
+++ b/src/agent/custom_views.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Type
 
 from browser_use.agent.views import AgentOutput
 from browser_use.controller.registry.views import ActionModel
@@ -41,8 +40,8 @@ class CustomAgentOutput(AgentOutput):
 
     @staticmethod
     def type_with_custom_actions(
-        custom_actions: Type[ActionModel],
-    ) -> Type["CustomAgentOutput"]:
+        custom_actions: type[ActionModel],
+    ) -> type["CustomAgentOutput"]:
         """Extend actions with custom actions"""
         return create_model(
             "CustomAgentOutput",

--- a/src/controller/custom_controller.py
+++ b/src/controller/custom_controller.py
@@ -1,5 +1,4 @@
 import pyperclip
-from typing import Optional, Type
 from pydantic import BaseModel
 from browser_use.agent.views import ActionResult
 from browser_use.browser.context import BrowserContext
@@ -8,7 +7,7 @@ from browser_use.controller.service import Controller, DoneAction
 
 class CustomController(Controller):
     def __init__(self, exclude_actions: list[str] = [],
-                output_model: Optional[Type[BaseModel]] = None
+                output_model: type[BaseModel] | None = None
                 ):
         super().__init__(exclude_actions=exclude_actions, output_model=output_model)
         self._register_custom_actions()

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -30,15 +30,7 @@ from langchain_core.output_parsers.base import OutputParserLike
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import BaseTool
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Literal,
-    Optional,
-    Union,
-    cast,
-)
+from typing import Any
 
 class DeepSeekR1ChatOpenAI(ChatOpenAI):
     
@@ -52,9 +44,9 @@ class DeepSeekR1ChatOpenAI(ChatOpenAI):
     async def ainvoke(
         self,
         input: LanguageModelInput,
-        config: Optional[RunnableConfig] = None,
+        config: RunnableConfig | None = None,
         *,
-        stop: Optional[list[str]] = None,
+        stop: list[str] | None = None,
         **kwargs: Any,
     ) -> AIMessage:
         message_history = []
@@ -78,9 +70,9 @@ class DeepSeekR1ChatOpenAI(ChatOpenAI):
     def invoke(
         self,
         input: LanguageModelInput,
-        config: Optional[RunnableConfig] = None,
+        config: RunnableConfig | None = None,
         *,
-        stop: Optional[list[str]] = None,
+        stop: list[str] | None = None,
         **kwargs: Any,
     ) -> AIMessage:
         message_history = []
@@ -106,9 +98,9 @@ class DeepSeekR1ChatOllama(ChatOllama):
     async def ainvoke(
         self,
         input: LanguageModelInput,
-        config: Optional[RunnableConfig] = None,
+        config: RunnableConfig | None = None,
         *,
-        stop: Optional[list[str]] = None,
+        stop: list[str] | None = None,
         **kwargs: Any,
     ) -> AIMessage:
         org_ai_message = await super().ainvoke(input=input)
@@ -122,9 +114,9 @@ class DeepSeekR1ChatOllama(ChatOllama):
     def invoke(
         self,
         input: LanguageModelInput,
-        config: Optional[RunnableConfig] = None,
+        config: RunnableConfig | None = None,
         *,
-        stop: Optional[list[str]] = None,
+        stop: list[str] | None = None,
         **kwargs: Any,
     ) -> AIMessage:
         org_ai_message = super().invoke(input=input)

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -2,7 +2,6 @@ import base64
 import os
 import time
 from pathlib import Path
-from typing import Dict, Optional
 
 from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -165,9 +164,9 @@ def encode_image(img_path):
     return image_data
 
 
-def get_latest_files(directory: str, file_types: list = ['.webm', '.zip']) -> Dict[str, Optional[str]]:
+def get_latest_files(directory: str, file_types: list = ['.webm', '.zip']) -> dict[str, str | None]:
     """Get the latest recording and trace files"""
-    latest_files: Dict[str, Optional[str]] = {ext: None for ext in file_types}
+    latest_files: dict[str, str | None] = {ext: None for ext in file_types}
     
     if not os.path.exists(directory):
         os.makedirs(directory, exist_ok=True)
@@ -219,5 +218,5 @@ async def capture_screenshot(browser_context):
         )
         encoded = base64.b64encode(screenshot).decode('utf-8')
         return encoded
-    except Exception as e:
+    except Exception:
         return None

--- a/webui.py
+++ b/webui.py
@@ -502,7 +502,7 @@ async def run_with_stream(
                         html_content = f'<img src="data:image/jpeg;base64,{encoded_screenshot}" style="width:{stream_vw}vw; height:{stream_vh}vh ; border:1px solid #ccc;">'
                     else:
                         html_content = f"<h1 style='width:{stream_vw}vw; height:{stream_vh}vh'>Waiting for browser session...</h1>"
-                except Exception as e:
+                except Exception:
                     html_content = f"<h1 style='width:{stream_vw}vw; height:{stream_vh}vh'>Waiting for browser session...</h1>"
 
                 if _global_agent_state and _global_agent_state.is_stop_requested():


### PR DESCRIPTION
Since this repo uses Python 3.11+, I updated the typing annotations to use the cleaner built-in generics like `list[str]`, `dict[str, Any]`, and `type[Something]` instead of the old `List[]`, `Dict[]`, and `Type[]`. Also replaced `Optional[]` with `| None` for better readability. As part of this, I removed most of the `typing` imports that were no longer needed after the change. Also removed redundant exception variables where they weren’t needed.