### PR TITLE
Fixing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ playwright install
    - WebUI: `http://localhost:7788`
    - VNC Viewer (to see browser interactions): `http://localhost:6080/vnc.html`
    
-   Default VNC password is "vncpassword". You can change it by setting the `VNC_PASSWORD` environment variable in your `.env` file.
+   Default VNC password is "youvncpassword". You can change it by setting the `VNC_PASSWORD` environment variable in your `.env` file.
 
 
 ## Usage


### PR DESCRIPTION
README states the default VNC password is `vncpassword` but it is actually `youvncpassword` in the env file