### PR TITLE
feat: add OpenAI O3-mini model support and fix theme handling

### DIFF
--- a/src/agent/custom_prompts.py
+++ b/src/agent/custom_prompts.py
@@ -14,7 +14,7 @@ class CustomSystemPrompt(SystemPrompt):
         """
         Returns the important rules for the agent.
         """
-        text = """
+        text = r"""
     1. RESPONSE FORMAT: You must ALWAYS respond with valid JSON in this exact format:
        {
          "current_state": {

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -140,7 +140,7 @@ def get_llm_model(provider: str, **kwargs):
 # Predefined model names for common providers
 model_names = {
     "anthropic": ["claude-3-5-sonnet-20240620", "claude-3-opus-20240229"],
-    "openai": ["gpt-4o", "gpt-4", "gpt-3.5-turbo"],
+    "openai": ["gpt-4o", "gpt-4", "gpt-3.5-turbo", "o3-mini"],
     "deepseek": ["deepseek-chat", "deepseek-reasoner"],
     "gemini": ["gemini-2.0-flash-exp", "gemini-2.0-flash-thinking-exp", "gemini-1.5-flash-latest", "gemini-1.5-flash-8b-latest", "gemini-2.0-flash-thinking-exp-1219" ],
     "ollama": ["qwen2.5:7b", "llama2:7b", "deepseek-r1:14b", "deepseek-r1:32b"],

--- a/webui.py
+++ b/webui.py
@@ -616,18 +616,8 @@ def create_ui(config, theme_name="Ocean"):
     }
     """
 
-    js = """
-    function refresh() {
-        const url = new URL(window.location);
-        if (url.searchParams.get('__theme') !== 'dark') {
-            url.searchParams.set('__theme', 'dark');
-            window.location.href = url.href;
-        }
-    }
-    """
-
     with gr.Blocks(
-            title="Browser Use WebUI", theme=theme_map[theme_name], css=css, js=js
+            title="Browser Use WebUI", theme=theme_map[theme_name], css=css
     ) as demo:
         with gr.Row():
             gr.Markdown(


### PR DESCRIPTION
# Add OpenAI O3-mini Model Support and Fix Theme Handling

## Changes
This PR introduces support for OpenAI's O3-mini model and fixes theme handling in the web UI.

### Features
1. **O3-mini Model Support**
   - Added O3-mini to the OpenAI model options
   - Updated model selection dropdown to include the new option

### Bug Fixes
1. **Theme Handling**
   - Removed forced dark theme JavaScript code
   - UI now respects system/browser theme preferences
   - Theme can be controlled via `--theme` argument or browser settings

2. **Code Improvements**
   - Fixed JSON template escape sequence in custom prompts
   - Improved code readability and maintainability

## Testing Done
- Verified O3-mini model appears in dropdown
- Confirmed theme switching works correctly
- Tested JSON template parsing

## Notes
- Users need appropriate OpenAI API access to use the O3-mini model
- Theme changes are now consistent with Gradio's theme system