### PR TITLE
feat: add missing endpoints and keys for Mistral and Anthropic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ OPENAI_ENDPOINT=https://api.openai.com/v1
 OPENAI_API_KEY=
 
 ANTHROPIC_API_KEY=
+ANTHROPIC_ENDPOINT=https://api.anthropic.com
 
 GOOGLE_API_KEY=
 
@@ -10,6 +11,9 @@ AZURE_OPENAI_API_KEY=
 
 DEEPSEEK_ENDPOINT=https://api.deepseek.com
 DEEPSEEK_API_KEY=
+
+MISTRAL_API_KEY=
+MISTRAL_ENDPOINT=https://api.mistral.ai/v1
 
 OLLAMA_ENDPOINT=http://localhost:11434
 


### PR DESCRIPTION
Added the missing endpoints for Anthropic (`ANTHROPIC_ENDPOINT`) and Mistral (`MISTRAL_ENDPOINT`) in the example env file. Also added Mistral's API key env var (`MISTRAL_API_KEY`).