### PR TITLE
added pyproject.toml so you can directly run the webui.py with uv run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "web-ui"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "browser-use==0.1.29",
+    "gradio==5.10.0",
+    "json-repair>=0.35.0",
+    "langchain-mistralai==0.2.4",
+    "pyperclip==1.9.0",
+]


### PR DESCRIPTION
using pyproject.toml for the requirements simplifies the setup if you have uv installed.

clone the repository, switch to the directory and run:
```bash
uv sync
```
then
```bash
source .venv/bin/activate # On Linux and macos
```
or
```bash
.venv\Scripts\activate # On Windows
```
then:
```bash
playwright install
```
and finally:
```bash
uv run webui.py
```