### PR TITLE
feat: update and add new google models

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -157,7 +157,7 @@ model_names = {
     "anthropic": ["claude-3-5-sonnet-20240620", "claude-3-opus-20240229"],
     "openai": ["gpt-4o", "gpt-4", "gpt-3.5-turbo", "o3-mini"],
     "deepseek": ["deepseek-chat", "deepseek-reasoner"],
-    "google": ["gemini-2.0-flash-exp", "gemini-2.0-flash-thinking-exp", "gemini-1.5-flash-latest", "gemini-1.5-flash-8b-latest", "gemini-2.0-flash-thinking-exp-01-21"],
+    "google": ["gemini-2.0-flash", "gemini-2.0-flash-thinking-exp", "gemini-1.5-flash-latest", "gemini-1.5-flash-8b-latest", "gemini-2.0-flash-thinking-exp-01-21", "gemini-2.0-pro-exp-02-05"],
     "ollama": ["qwen2.5:7b", "llama2:7b", "deepseek-r1:14b", "deepseek-r1:32b"],
     "azure_openai": ["gpt-4o", "gpt-4", "gpt-3.5-turbo"],
     "mistral": ["pixtral-large-latest", "mistral-large-latest", "mistral-small-latest", "ministral-8b-latest"],


### PR DESCRIPTION
Hello,

Thank you for creating such an amazing project!

Google Gemini 2.0 Flash is now GA and they have added 2.0 pro recently. This pr aims to correct the experimental Gemini 2.0 Flash name from `gemini-2.0-flash-exp` to `gemini-2.0-flash` and add support to 2.0 pro model.

ref: [Gemini 2.0](https://cloud.google.com/vertex-ai/generative-ai/docs/gemini-v2#2.0-pro)
ref: [Gemini models](https://ai.google.dev/gemini-api/docs/models/gemini#gemini-2.0-flash)