### PR TITLE
Fix: Ollama connection by updating default endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ DEEPSEEK_API_KEY=
 MISTRAL_API_KEY=
 MISTRAL_ENDPOINT=https://api.mistral.ai/v1
 
-OLLAMA_ENDPOINT=http://localhost:11434
+OLLAMA_ENDPOINT=http://host.docker.internal:11434
 
 ALIBABA_ENDPOINT=https://dashscope.aliyuncs.com/compatible-mode/v1
 ALIBABA_API_KEY=

--- a/src/agent/custom_agent.py
+++ b/src/agent/custom_agent.py
@@ -1,31 +1,38 @@
-import base64
-import io
 import json
 import logging
+import pdb
+import traceback
+from typing import Optional, Type, List, Dict, Any, Callable
+from PIL import Image, ImageDraw, ImageFont
 import os
+import base64
+import io
 import platform
-from typing import Any, Callable, Dict, List, Optional, Type
-
-from browser_use.agent.prompts import AgentMessagePrompt, PlannerPrompt, SystemPrompt
+from browser_use.agent.prompts import SystemPrompt, AgentMessagePrompt
 from browser_use.agent.service import Agent
 from browser_use.agent.views import (
-    ActionModel,
     ActionResult,
+    ActionModel,
     AgentHistoryList,
     AgentOutput,
+    AgentHistory,
 )
 from browser_use.browser.browser import Browser
 from browser_use.browser.context import BrowserContext
+from browser_use.browser.views import BrowserStateHistory
 from browser_use.controller.service import Controller
 from browser_use.telemetry.views import (
     AgentEndTelemetryEvent,
+    AgentRunTelemetryEvent,
     AgentStepTelemetryEvent,
 )
 from browser_use.utils import time_execution_async
-from json_repair import repair_json
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import BaseMessage, HumanMessage
-from PIL import Image, ImageFont
+from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
+from browser_use.agent.prompts import PlannerPrompt
+
+from json_repair import repair_json
+from src.utils.agent_state import AgentState
 
 from .custom_message_manager import CustomMessageManager
 from .custom_views import CustomAgentOutput, CustomAgentStepInfo
@@ -571,4 +578,4 @@ class CustomAgent(Agent):
             )
             logger.info(f'Created GIF at {output_path}')
         else:
-            logger.warning('No images found in history to create GIF')
+            logger.warning("No images found in history to create GIF")

--- a/src/agent/custom_agent.py
+++ b/src/agent/custom_agent.py
@@ -88,6 +88,7 @@ class CustomAgent(Agent):
         planner_llm: Optional[BaseChatModel] = None,
         planner_interval: int = 1,  # Run planner every N steps
     ):
+
         # Load sensitive data from environment variables
         env_sensitive_data = {}
         for key, value in os.environ.items():


### PR DESCRIPTION
When using Ollama with Browser-Use, the default endpoint http://localhost:11434 causes connection refused errors because the Docker container cannot access the host machine's localhost. This PR updates the default Ollama endpoint to use http://host.docker.internal:11434, allowing the container to communicate with Ollama running on the host machine properly.

I've seen a lot of problems with this : https://github.com/browser-use/web-ui/issues?q=connection%20refused