### PR TITLE
Fix: Ollama connection by updating default endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ DEEPSEEK_API_KEY=
 MISTRAL_API_KEY=
 MISTRAL_ENDPOINT=https://api.mistral.ai/v1
 
-OLLAMA_ENDPOINT=http://localhost:11434
+OLLAMA_ENDPOINT=http://host.docker.internal:11434
 
 ALIBABA_ENDPOINT=https://dashscope.aliyuncs.com/compatible-mode/v1
 ALIBABA_API_KEY=


### PR DESCRIPTION
When using Ollama with Browser-Use, the default endpoint http://localhost:11434/ causes connection refused errors because the Docker container cannot access the host machine's localhost. This PR updates the default Ollama endpoint to use http://host.docker.internal:11434/, allowing the container to communicate with Ollama running on the host machine properly.

I've seen a lot of problems with this : https://github.com/browser-use/web-ui/issues?q=connection%20refused