### PR TITLE
Fix `ModuleNotFoundError: No module named 'langchain'`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ json-repair
 langchain-mistralai==0.2.4
 langchain-google-genai==2.0.8
 MainContentExtractor==0.0.4
+langchain>=0.3.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ json-repair
 langchain-mistralai==0.2.4
 langchain-google-genai==2.0.8
 MainContentExtractor==0.0.4
-langchain>=0.3.21
+langchain>=0.1.12


### PR DESCRIPTION
- Fixes `ModuleNotFoundError: No module named 'langchain'`

Reproduce: start a deep research and you'll get this error.


Detailed log:
```bash
browser-use-webui-1  | Traceback (most recent call last):
browser-use-webui-1  | 2025-03-20 14:45:08,029 DEBG 'webui' stderr output:
browser-use-webui-1  | Traceback (most recent call last):
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/queueing.py", line 625, in process_events
browser-use-webui-1  |     response = await route_utils.call_process_api(
browser-use-webui-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/route_utils.py", line 322, in call_process_api
browser-use-webui-1  |     output = await app.get_blocks().process_api(
browser-use-webui-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/blocks.py", line 2045, in process_api
browser-use-webui-1  |     result = await self.call_function(
browser-use-webui-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  | 
browser-use-webui-1  | 2025-03-20 14:45:08,029 DEBG 'webui' stderr output:
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/blocks.py", line 1590, in call_function
browser-use-webui-1  |     prediction = await fn(*processed_input)
browser-use-webui-1  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/utils.py", line 837, in async_wrapper
browser-use-webui-1  |     response = await f(*args, **kwargs)
browser-use-webui-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/app/webui.py", line 692, in run_deep_search
browser-use-webui-1  |     from src.utils.deep_research import deep_research
browser-use-webui-1  |   File "/app/src/utils/deep_research.py", line 22, in <module>
browser-use-webui-1  |     from langchain.schema import SystemMessage, HumanMessage
browser-use-webui-1  | ModuleNotFoundError: No module named 'langchain'
browser-use-webui-1  | Traceback (most recent call last):
browser-use-webui-1  | 
browser-use-webui-1  | 2025-03-20 14:45:08,029 DEBG 'webui' stderr output:
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/queueing.py", line 625, in process_events
browser-use-webui-1  |     response = await route_utils.call_process_api(
browser-use-webui-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/route_utils.py", line 322, in call_process_api
browser-use-webui-1  |     output = await app.get_blocks().process_api(
browser-use-webui-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/blocks.py", line 2045, in process_api
browser-use-webui-1  |     result = await self.call_function(
browser-use-webui-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/blocks.py", line 1590, in call_function
browser-use-webui-1  |     prediction = await fn(*processed_input)
browser-use-webui-1  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/utils.py", line 837, in async_wrapper
browser-use-webui-1  |     response = await f(*args, **kwargs)
browser-use-webui-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/app/webui.py", line 692, in run_deep_search
browser-use-webui-1  |     from src.utils.deep_research import deep_research
browser-use-webui-1  |   File "/app/src/utils/deep_research.py", line 22, in <module>
browser-use-webui-1  |     from langchain.schema import SystemMessage, HumanMessage
browser-use-webui-1  | ModuleNotFoundError: No module named 'langchain'
browser-use-webui-1  | 
browser-use-webui-1  | 2025-03-20 14:45:08,029 DEBG 'webui' stderr output:
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/queueing.py", line 625, in process_events
browser-use-webui-1  |     response = await route_utils.call_process_api(
browser-use-webui-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/route_utils.py", line 322, in call_process_api
browser-use-webui-1  |     output = await app.get_blocks().process_api(
browser-use-webui-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/blocks.py", line 2045, in process_api
browser-use-webui-1  |     result = await self.call_function(
browser-use-webui-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/blocks.py", line 1590, in call_function
browser-use-webui-1  |     prediction = await fn(*processed_input)
browser-use-webui-1  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/usr/local/lib/python3.11/site-packages/gradio/utils.py", line 837, in async_wrapper
browser-use-webui-1  |     response = await f(*args, **kwargs)
browser-use-webui-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^
browser-use-webui-1  |   File "/app/webui.py", line 692, in run_deep_search
browser-use-webui-1  |     from src.utils.deep_research import deep_research
browser-use-webui-1  |   File "/app/src/utils/deep_research.py", line 22, in <module>
browser-use-webui-1  |     from langchain.schema import SystemMessage, HumanMessage
browser-use-webui-1  | ModuleNotFoundError: No module named 'langchain'
```