### PR TITLE
Correct Mistral's multimodal model name

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -173,7 +173,7 @@ model_names = {
     "ollama": ["qwen2.5:7b", "qwen2.5:14b", "qwen2.5:32b", "qwen2.5-coder:14b", "qwen2.5-coder:32b", "llama2:7b",
                "deepseek-r1:14b", "deepseek-r1:32b"],
     "azure_openai": ["gpt-4o", "gpt-4", "gpt-3.5-turbo"],
-    "mistral": ["mixtral-large-latest", "mistral-large-latest", "mistral-small-latest", "ministral-8b-latest"],
+    "mistral": ["pixtral-large-latest", "mistral-large-latest", "mistral-small-latest", "ministral-8b-latest"],
     "alibaba": ["qwen-plus", "qwen-max", "qwen-turbo", "qwen-long"],
     "moonshot": ["moonshot-v1-32k-vision-preview", "moonshot-v1-8k-vision-preview"],
 }


### PR DESCRIPTION
According to Mistral's documantation: https://docs.mistral.ai/getting-started/models/models_overview/ there is no such model as `mixtral-large-latest` there is, however, `pixtral-large-latest`. This looks like a typo introduced a few days ago.