### PR TITLE
Fixes Typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN git clone https://github.com/novnc/noVNC.git /opt/novnc \
     && git clone https://github.com/novnc/websockify /opt/novnc/utils/websockify \
     && ln -s /opt/novnc/vnc.html /opt/novnc/index.html
 
-# Set platform for ARM64 compatibility
+# Set platform for AMD64 compatibility
 ARG TARGETPLATFORM=linux/amd64
 
 # Set up working directory


### PR DESCRIPTION
Probably Copy Paste error --> Corrected ARM64 to AMD64
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed a typo in the Dockerfile comment to correctly state AMD64 instead of ARM64.

<!-- End of auto-generated description by mrge. -->

