### PR TITLE
Added IBM watsonx model support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ UNBOUND_API_KEY=
 SiliconFLOW_ENDPOINT=https://api.siliconflow.cn/v1/
 SiliconFLOW_API_KEY=
 
+IBM_ENDPOINT=https://us-south.ml.cloud.ibm.com
+IBM_API_KEY=
+IBM_PROJECT_ID=
 # Set to false to disable anonymized telemetry
 ANONYMIZED_TELEMETRY=false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
       - ALIBABA_ENDPOINT=${ALIBABA_ENDPOINT:-https://dashscope.aliyuncs.com/compatible-mode/v1}
       - ALIBABA_API_KEY=${ALIBABA_API_KEY:-}
       - MOONSHOT_ENDPOINT=${MOONSHOT_ENDPOINT:-https://api.moonshot.cn/v1}
+      - IBM_API_KEY=${IBM_API_KEY:-}
+      - IBM_ENDPOINT=${IBM_ENDPOINT:-https://us-south.ml.cloud.ibm.com}
+      - IBM_PROJECT_ID=${IBM_PROJECT_ID:-}
       - MOONSHOT_API_KEY=${MOONSHOT_API_KEY:-}
       - BROWSER_USE_LOGGING_LEVEL=${BROWSER_USE_LOGGING_LEVEL:-info}
       - ANONYMIZED_TELEMETRY=${ANONYMIZED_TELEMETRY:-false}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ gradio==5.23.1
 json-repair
 langchain-mistralai==0.2.4
 langchain-google-genai==2.0.8
+langchain-ibm==0.3.10
 MainContentExtractor==0.0.4

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -158,7 +158,7 @@ def get_llm_model(provider: str, **kwargs):
         )
     elif provider == "ibm":
         parameters = {
-            "temperature": kwargs.get("temperature", 0.6),
+            "temperature": kwargs.get("temperature", 0.0),
             "max_tokens": kwargs.get("num_ctx", 32000)
         }
         if not kwargs.get("base_url", ""):

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -13,6 +13,7 @@ from langchain_mistralai import ChatMistralAI
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_ollama import ChatOllama
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
+from langchain_ibm import ChatWatsonx
 
 from .llm import DeepSeekR1ChatOpenAI, DeepSeekR1ChatOllama
 
@@ -24,8 +25,9 @@ PROVIDER_DISPLAY_NAMES = {
     "google": "Google",
     "alibaba": "Alibaba",
     "moonshot": "MoonShot",
-    "unbound": "Unbound AI"
-}
+    "unbound": "Unbound AI",
+    "ibm": "IBM"
+    }
 
 
 def get_llm_model(provider: str, **kwargs):
@@ -154,6 +156,23 @@ def get_llm_model(provider: str, **kwargs):
             base_url=base_url,
             api_key=api_key,
         )
+    elif provider == "ibm":
+        parameters = {
+            "temperature": kwargs.get("temperature", 0.6),
+            "max_tokens": kwargs.get("num_ctx", 32000)
+        }
+        if not kwargs.get("base_url", ""):
+            base_url = os.getenv("IBM_ENDPOINT", "https://us-south.ml.cloud.ibm.com")
+        else:
+            base_url = kwargs.get("base_url")
+
+        return ChatWatsonx(
+            model_id=kwargs.get("model_name", "ibm/granite-vision-3.1-2b-preview"),
+            url=base_url,
+            project_id=os.getenv("IBM_PROJECT_ID"),
+            apikey=os.getenv("IBM_API_KEY"),
+            params=parameters
+        )
     elif provider == "moonshot":
         return ChatOpenAI(
             model=kwargs.get("model_name", "moonshot-v1-32k-vision-preview"),
@@ -234,6 +253,7 @@ model_names = {
         "Pro/THUDM/chatglm3-6b",
         "Pro/THUDM/glm-4-9b-chat",
     ],
+    "ibm": ["meta-llama/llama-4-maverick-17b-128e-instruct-fp8","meta-llama/llama-3-2-90b-vision-instruct"]
 }
 
 

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -41,6 +41,7 @@ def get_env_value(key, provider):
         "mistral": {"api_key": "MISTRAL_API_KEY", "base_url": "MISTRAL_ENDPOINT"},
         "alibaba": {"api_key": "ALIBABA_API_KEY", "base_url": "ALIBABA_ENDPOINT"},
         "moonshot":{"api_key": "MOONSHOT_API_KEY", "base_url": "MOONSHOT_ENDPOINT"},
+        "ibm": {"api_key": "IBM_API_KEY", "base_url": "IBM_ENDPOINT"}
     }
 
     if provider in env_mappings and key in env_mappings[provider]:
@@ -126,12 +127,17 @@ def test_moonshot_model():
     config = LLMConfig(provider="moonshot", model_name="moonshot-v1-32k-vision-preview")
     test_llm(config, "Describe this image", "assets/examples/test.png")
 
+def test_ibm_model():
+    config = LLMConfig(provider="ibm", model_name="meta-llama/llama-4-maverick-17b-128e-instruct-fp8")
+    test_llm(config, "Describe this image", "assets/examples/test.png")
+
 if __name__ == "__main__":
     # test_openai_model()
     # test_google_model()
     # test_azure_openai_model()
     #test_deepseek_model()
     # test_ollama_model()
-    test_deepseek_r1_model()
+    # test_deepseek_r1_model()
     # test_deepseek_r1_ollama_model()
     # test_mistral_model()
+    test_ibm_model()


### PR DESCRIPTION
This PR adds IBM watsonx model support to browser-use web-ui
It covers the below changes

- Updated `.env.example` and `docker-compose.yml` files to include IBM watsonx environment variables 
- Added `langchain-ibm==0.3.10` as a dependency
- Added `ibm` as a model provider along with the `ChatWatsonx` support
- Added a test case to verify the changes
- Attached a screenshot of the test case execution
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/0dca5b9d-ef4f-4251-8f0a-e88373152925" />

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added support for IBM watsonx models, allowing users to select IBM as a provider in the web UI.

- **Dependencies**
  - Added langchain-ibm to requirements.
  - Updated environment and Docker files for IBM credentials.

- **New Features**
  - Enabled IBM watsonx model selection and usage.
  - Added a test case for IBM model integration.

<!-- End of auto-generated description by mrge. -->

