### PR TITLE
chore: remove duplicate imports

### DIFF
--- a/src/utils/mcp_client.py
+++ b/src/utils/mcp_client.py
@@ -1,28 +1,15 @@
-import os
-import asyncio
-import base64
-import pdb
-from typing import List, Tuple, Optional
-from langchain_core.tools import BaseTool
-from langchain_mcp_adapters.client import MultiServerMCPClient
-import base64
-import json
+import inspect
 import logging
-from typing import Optional, Dict, Any, Type
-from langchain_core.tools import BaseTool
-from pydantic.v1 import BaseModel, Field
-from langchain_core.runnables import RunnableConfig
-from pydantic import BaseModel, Field, create_model
-from typing import Type, Dict, Any, Optional, get_type_hints, List, Union, Annotated, Set
-from pydantic import BaseModel, ConfigDict, create_model, Field
-from langchain.tools import BaseTool
-import inspect
-from datetime import datetime, date, time
 import uuid
+from datetime import date, datetime, time
 from enum import Enum
-import inspect
+from typing import Any, Dict, List, Optional, Set, Type, Union, get_type_hints
+
 from browser_use.controller.registry.views import ActionModel
-from typing import Type, Dict, Any, Optional, get_type_hints
+from langchain.tools import BaseTool
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from pydantic import BaseModel, Field, create_model
+from pydantic.v1 import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Removed duplicates and unused imports in `/src/utils/mcp_client.py`
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Removed duplicate and unused imports from `mcp_client.py` to clean up the code and reduce clutter.

<!-- End of auto-generated description by mrge. -->

