### PR TITLE
fix: address gradio deprecation warnings

### DIFF
--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -989,7 +989,6 @@ def create_browser_use_agent_tab(webui_manager: WebuiManager):
             type="messages",
             height=600,
             show_copy_button=True,
-            bubble_full_width=False,
         )
         user_input = gr.Textbox(
             label="Your Task or Response",

--- a/src/webui/webui_manager.py
+++ b/src/webui/webui_manager.py
@@ -104,7 +104,10 @@ class WebuiManager:
         for comp_id, comp_val in ui_settings.items():
             if comp_id in self.id_to_component:
                 comp = self.id_to_component[comp_id]
-                update_components[comp] = comp.__class__(value=comp_val)
+                if comp.__class__.__name__ == "Chatbot":
+                    update_components[comp] = comp.__class__(value=comp_val, type="messages")
+                else:
+                    update_components[comp] = comp.__class__(value=comp_val)
 
         config_status = self.id_to_component["load_save_config.config_status"]
         update_components.update(


### PR DESCRIPTION
This PR addresses two Gradio deprecation warnings. It fixes the following issues:

1.  `...\web-ui\.venv\Lib\site-packages\gradio\blocks.py:1925: DeprecationWarning: The 'bubble_full_width' parameter is deprecated and will be removed in a future version. This parameter no longer has any effect.`

2.  `...\web-ui\src\webui\webui_manager.py:107: UserWarning: You have not specified a value for the 'type' parameter. Defaulting to the 'tuples' format for chatbot messages, but this is deprecated and will be removed in a future version of Gradio. Please set type='messages' instead...`

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Removed deprecated Gradio parameters and set the correct type for chatbot messages to resolve deprecation warnings.

- **Bug Fixes**
  - Removed the unused bubble_full_width parameter.
  - Set type="messages" for chatbot components to avoid future warnings.

<!-- End of auto-generated description by mrge. -->

