### PR TITLE
Update custom_browser.py

### DIFF
--- a/src/browser/custom_browser.py
+++ b/src/browser/custom_browser.py
@@ -1,17 +1,17 @@
 import asyncio
 import pdb
 
-from patchright.async_api import Browser as PlaywrightBrowser
-from patchright.async_api import (
+from playwright.async_api import Browser as PlaywrightBrowser
+from playwright.async_api import (
     BrowserContext as PlaywrightBrowserContext,
 )
-from patchright.async_api import (
+from playwright.async_api import (
     Playwright,
     async_playwright,
 )
 from browser_use.browser.browser import Browser, IN_DOCKER
 from browser_use.browser.context import BrowserContext, BrowserContextConfig
-from patchright.async_api import BrowserContext as PlaywrightBrowserContext
+from playwright.async_api import BrowserContext as PlaywrightBrowserContext
 import logging
 
 from browser_use.browser.chrome import (


### PR DESCRIPTION
Fixed typo with patchright to playwright 
That caused a module error not found when trying to start up web-ui

![image](https://github.com/user-attachments/assets/c986a7eb-65f1-45cc-b1aa-da328a7d4984)
