### PR TITLE
Update Dockerfile to install playwright via npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y \
     fonts-dejavu \
     fonts-dejavu-core \
     fonts-dejavu-extra \
+    nodejs npm \
     && rm -rf /var/lib/apt/lists/*
 
 # Install noVNC
@@ -59,8 +60,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Install Playwright and browsers with system dependencies
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN playwright install --with-deps chromium
-RUN playwright install-deps
+RUN npm init playwright@latest --with-deps chromium
+RUN npm init playwright@latest install-deps
 
 # Copy the application code
 COPY . .


### PR DESCRIPTION
Docker install has an error on playright. use npm to install playwright instead
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated the Dockerfile to install Playwright using npm instead of the system package to fix installation errors. 

- **Dependencies**
  - Added nodejs and npm installation.
  - Replaced Playwright install commands with npm-based installation.

<!-- End of auto-generated description by mrge. -->

