### PR TITLE
set metadata to optional

### DIFF
--- a/src/workflows/controller/views.py
+++ b/src/workflows/controller/views.py
@@ -13,8 +13,8 @@ class _BaseExtra(BaseModel):
 
 # Mixin for shared step metadata (timestamp and tab context)
 class StepMeta(_BaseExtra):
-    timestamp: int
-    tabId: int
+    timestamp: Optional[int] = None
+    tabId: Optional[int] = None
 
 
 # Common optional fields present in recorder events


### PR DESCRIPTION
in the execution phase metadata is optional.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Made the timestamp and tabId fields in step metadata optional during execution.

<!-- End of auto-generated description by mrge. -->

