### PR TITLE
Update patchright in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,9 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Install Playwright and browsers with system dependencies
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN playwright install --with-deps chromium
-RUN playwright install-deps
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-patchright
+RUN patchright install --with-deps chromium
+RUN patchright install-deps
 
 # Copy the application code
 COPY . .


### PR DESCRIPTION
# Summary
update the Dockerfile to use Patchright instead of Playwright, addressing [[Issue #574](https://github.com/browser-use/web-ui/issues/574)](https://github.com/browser-use/web-ui/issues/574).

# Changes Made
* Set `ENV PLAYWRIGHT_BROWSERS_PATH=/ms-patchright` to define the browser installation path for Patchright
* Replaced Playwright installation commands with Patchright equivalents:
  ```dockerfile
  RUN patchright install --with-deps chromium
  RUN patchright install-deps
  ```

# Testing
- Verified that the container builds successfully with the new configuration

# Related Issues
Closes [[Issue #574](https://github.com/browser-use/web-ui/issues/574)](https://github.com/browser-use/web-ui/issues/574)


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated the Dockerfile to use Patchright instead of Playwright for browser installation and dependencies.

- **Dependencies**
  - Set the browser path to /ms-patchright.
  - Replaced Playwright install commands with Patchright equivalents.

<!-- End of auto-generated description by mrge. -->

