### PR TITLE
Update patchright in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,10 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Install Playwright and browsers with system dependencies
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN playwright install --with-deps chromium
-RUN playwright install-deps
+# Install patchright and browsers with system dependencies
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-patchright
+RUN patchright install --with-deps chromium
+RUN patchright install-deps
 
 # Copy the application code
 COPY . .


### PR DESCRIPTION
# Summary
Update the Dockerfile to use Patchright instead of Playwright, addressing issue #574 

# Changes Made
* Set `ENV PLAYWRIGHT_BROWSERS_PATH=/ms-patchright` to define the browser installation path for Patchright
* Replaced Playwright installation commands with Patchright equivalents:
  ```dockerfile
  RUN patchright install --with-deps chromium
  RUN patchright install-deps
  ```

# Testing
- Verified that the container builds successfully with the new configuration

# Related Issues
Closes #574 

# 
Sorry, I deleted the repo accidentally. This PR is same to #579