### PR TITLE
Update PLAYWRIGHT_BROWSERS_PATH in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Install patchright and browsers with system dependencies
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-patchright
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN patchright install --with-deps chromium
 RUN patchright install-deps
 


### PR DESCRIPTION
## Summary
fixe the browser path environment variable for Patchright

## Changes
- Corrected `ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` to `ENV PLAYWRIGHT_BROWSERS_PATH=/ms-patchright`
- This change ensures the compatibility between CHROME_PATH and PLAYWRIGHT_BROWSERS_PATH.

## Related Issues
Fixes previous PR #580 
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed the PLAYWRIGHT_BROWSERS_PATH in the Dockerfile to use /ms-playwright for better compatibility with CHROME_PATH.

<!-- End of auto-generated description by mrge. -->

