### PR TITLE
upgrade to bu==0.1.47

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,24 +67,23 @@ WORKDIR /app
 
 # Copy requirements and install Python dependencies
 COPY requirements.txt .
-# Ensure 'patchright' is in your requirements.txt or install it directly
-# RUN pip install --no-cache-dir -r requirements.txt patchright # If not in requirements
+
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Install Patchright browsers and dependencies
-# Patchright documentation suggests PLAYWRIGHT_BROWSERS_PATH is still relevant
-# or that Patchright installs to a similar default location that Playwright would.
-# Let's assume Patchright respects PLAYWRIGHT_BROWSERS_PATH or its default install location is findable.
+# Install playwright browsers and dependencies
+# playwright documentation suggests PLAYWRIGHT_BROWSERS_PATH is still relevant
+# or that playwright installs to a similar default location that Playwright would.
+# Let's assume playwright respects PLAYWRIGHT_BROWSERS_PATH or its default install location is findable.
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-browsers
 RUN mkdir -p $PLAYWRIGHT_BROWSERS_PATH
 
 # Install recommended: Google Chrome (instead of just Chromium for better undetectability)
-# The 'patchright install chrome' command might download and place it.
-# The '--with-deps' equivalent for patchright install is to run 'patchright install-deps chrome' after.
-# RUN patchright install chrome --with-deps
+# The 'playwright install chrome' command might download and place it.
+# The '--with-deps' equivalent for playwright install is to run 'playwright install-deps chrome' after.
+# RUN playwright install chrome --with-deps
 
 # Alternative: Install Chromium if Google Chrome is problematic in certain environments
-RUN patchright install chromium --with-deps
+RUN playwright install chromium --with-deps
 
 
 # Copy the application code

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ Install Python packages:
 uv pip install -r requirements.txt
 ```
 
-Install Browsers in Patchright. 
+Install Browsers in playwright. 
 ```bash
-patchright install --with-deps
+playwright install --with-deps
 ```
 Or you can install specific browsers by running:
 ```bash
-patchright install chromium --with-deps
+playwright install chromium --with-deps
 ```
 
 #### Step 4: Configure Environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
 
       # Display Settings
       - DISPLAY=:99
-      # This ENV is used by the Dockerfile during build time if Patchright respects it.
+      # This ENV is used by the Dockerfile during build time if playwright respects it.
       # It's not strictly needed at runtime by docker-compose unless your app or scripts also read it.
       - PLAYWRIGHT_BROWSERS_PATH=/ms-browsers # Matches Dockerfile ENV
       - RESOLUTION=${RESOLUTION:-1920x1080x24}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-browser-use==0.1.45
+browser-use==0.1.47
 pyperclip==1.9.0
 gradio==5.27.0
 json-repair

--- a/src/agent/browser_use/browser_use_agent.py
+++ b/src/agent/browser_use/browser_use_agent.py
@@ -15,9 +15,6 @@ from browser_use.agent.views import (
     ToolCallingMethod,
 )
 from browser_use.browser.views import BrowserStateHistory
-from browser_use.telemetry.views import (
-    AgentEndTelemetryEvent,
-)
 from browser_use.utils import time_execution_async
 from dotenv import load_dotenv
 from browser_use.agent.message_manager.utils import is_model_without_tool_support
@@ -143,19 +140,6 @@ class BrowserUseAgent(Agent):
         finally:
             # Unregister signal handlers before cleanup
             signal_handler.unregister()
-
-            self.telemetry.capture(
-                AgentEndTelemetryEvent(
-                    agent_id=self.state.agent_id,
-                    is_done=self.state.history.is_done(),
-                    success=self.state.history.is_successful(),
-                    steps=self.state.n_steps,
-                    max_steps_reached=self.state.n_steps >= max_steps,
-                    errors=self.state.history.errors(),
-                    total_input_tokens=self.state.history.total_input_tokens(),
-                    total_duration_seconds=self.state.history.total_duration_seconds(),
-                )
-            )
 
             if self.settings.save_playwright_script_path:
                 logger.info(

--- a/src/agent/deep_research/deep_research_agent.py
+++ b/src/agent/deep_research/deep_research_agent.py
@@ -81,7 +81,7 @@ async def run_single_browser_task(
     bu_browser_context = None
     try:
         logger.info(f"Starting browser task for query: {task_query}")
-        extra_args = [f"--window-size={window_w},{window_h}"]
+        extra_args = []
         if use_own_browser:
             browser_binary_path = os.getenv("BROWSER_PATH", None) or browser_binary_path
             if browser_binary_path == "":
@@ -99,6 +99,10 @@ async def run_single_browser_task(
                 extra_browser_args=extra_args,
                 wss_url=wss_url,
                 cdp_url=cdp_url,
+                new_context_config=BrowserContextConfig(
+                    window_width=window_w,
+                    window_height=window_h,
+                )
             )
         )
 

--- a/src/browser/custom_context.py
+++ b/src/browser/custom_context.py
@@ -4,8 +4,8 @@ import os
 
 from browser_use.browser.browser import Browser, IN_DOCKER
 from browser_use.browser.context import BrowserContext, BrowserContextConfig
-from patchright.async_api import Browser as PlaywrightBrowser
-from patchright.async_api import BrowserContext as PlaywrightBrowserContext
+from playwright.async_api import Browser as PlaywrightBrowser
+from playwright.async_api import BrowserContext as PlaywrightBrowserContext
 from typing import Optional
 from browser_use.browser.context import BrowserContextState
 

--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -450,7 +450,7 @@ async def run_agent_task(
         # Create Browser if needed
         if not webui_manager.bu_browser:
             logger.info("Launching new browser instance.")
-            extra_args = [f"--window-size={window_w},{window_h}"]
+            extra_args = []
             if use_own_browser:
                 browser_binary_path = os.getenv("BROWSER_PATH", None) or browser_binary_path
                 if browser_binary_path == "":
@@ -469,6 +469,10 @@ async def run_agent_task(
                     extra_browser_args=extra_args,
                     wss_url=wss_url,
                     cdp_url=cdp_url,
+                    new_context_config=BrowserContextConfig(
+                        window_width=window_w,
+                        window_height=window_h,
+                    )
                 )
             )
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -29,20 +29,18 @@ async def test_browser_use_agent():
     from src.utils import llm_provider
     from src.agent.browser_use.browser_use_agent import BrowserUseAgent
 
-    # llm = utils.get_llm_model(
-    #     provider="openai",
-    #     model_name="gpt-4o",
-    #     temperature=0.8,
-    #     base_url=os.getenv("OPENAI_ENDPOINT", ""),
-    #     api_key=os.getenv("OPENAI_API_KEY", ""),
-    # )
-
     llm = llm_provider.get_llm_model(
-        provider="google",
-        model_name="gemini-2.0-flash",
-        temperature=0.6,
-        api_key=os.getenv("GOOGLE_API_KEY", "")
+        provider="openai",
+        model_name="gpt-4o",
+        temperature=0.8,
     )
+
+    # llm = llm_provider.get_llm_model(
+    #     provider="google",
+    #     model_name="gemini-2.0-flash",
+    #     temperature=0.6,
+    #     api_key=os.getenv("GOOGLE_API_KEY", "")
+    # )
 
     # llm = utils.get_llm_model(
     #     provider="deepseek",
@@ -104,7 +102,7 @@ async def test_browser_use_agent():
     browser_context = None
 
     try:
-        extra_browser_args = [f"--window-size={window_w},{window_h}"]
+        extra_browser_args = []
         if use_own_browser:
             browser_binary_path = os.getenv("BROWSER_PATH", None)
             if browser_binary_path == "":
@@ -119,6 +117,10 @@ async def test_browser_use_agent():
                 headless=False,
                 browser_binary_path=browser_binary_path,
                 extra_browser_args=extra_browser_args,
+                new_context_config=BrowserContextConfig(
+                    window_width=window_w,
+                    window_height=window_h,
+                )
             )
         )
         browser_context = await browser.new_context(
@@ -256,7 +258,7 @@ async def test_browser_use_parallel():
     browser_context = None
 
     try:
-        extra_browser_args = [f"--window-size={window_w},{window_h}"]
+        extra_browser_args = []
         if use_own_browser:
             browser_binary_path = os.getenv("BROWSER_PATH", None)
             if browser_binary_path == "":
@@ -271,6 +273,10 @@ async def test_browser_use_parallel():
                 headless=False,
                 browser_binary_path=browser_binary_path,
                 extra_browser_args=extra_browser_args,
+                new_context_config=BrowserContextConfig(
+                    window_width=window_w,
+                    window_height=window_h,
+                )
             )
         )
         browser_context = await browser.new_context(

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 def test_connect_browser():
     import os
-    from patchright.sync_api import sync_playwright
+    from playwright.sync_api import sync_playwright
 
     chrome_exe = os.getenv("CHROME_PATH", "")
     chrome_use_data = os.getenv("CHROME_USER_DATA", "")


### PR DESCRIPTION
1. upgrade bu==0.1.47
2. change patchright to playwright
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Upgraded browser-use to version 0.1.47 and replaced all uses of patchright with playwright for browser automation.

- **Dependencies**
  - Updated requirements and Docker setup to use playwright instead of patchright.

- **Refactors**
  - Changed all imports and commands from patchright to playwright.
  - Updated browser launch logic and tests to use new context configuration for window size.

<!-- End of auto-generated description by mrge. -->

