### PR TITLE
Fix uncontrolled data used in path expression

### DIFF
--- a/src/agent/deep_research/deep_research_agent.py
+++ b/src/agent/deep_research/deep_research_agent.py
@@ -1111,7 +1111,12 @@ class DeepResearchAgent:
             }
 
         self.current_task_id = task_id if task_id else str(uuid.uuid4())
-        output_dir = os.path.join(save_dir, self.current_task_id)
+        safe_root_dir = "./tmp/deep_research"
+        normalized_save_dir = os.path.normpath(save_dir)
+        if not normalized_save_dir.startswith(os.path.abspath(safe_root_dir)):
+            logger.warning(f"Unsafe save_dir detected: {save_dir}. Using default directory.")
+            normalized_save_dir = os.path.abspath(safe_root_dir)
+        output_dir = os.path.join(normalized_save_dir, self.current_task_id)
         os.makedirs(output_dir, exist_ok=True)
 
         logger.info(

--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -77,7 +77,7 @@ async def run_deep_research(webui_manager: WebuiManager, components: Dict[Compon
     base_save_dir = components.get(save_dir_comp, "./tmp/deep_research").strip()
     safe_root_dir = "./tmp/deep_research"
     normalized_base_save_dir = os.path.normpath(base_save_dir)
-    if not normalized_base_save_dir.startswith(os.path.abspath(safe_root_dir)):
+    if os.path.commonpath([normalized_base_save_dir, os.path.abspath(safe_root_dir)]) != os.path.abspath(safe_root_dir):
         logger.warning(f"Unsafe base_save_dir detected: {base_save_dir}. Using default directory.")
         normalized_base_save_dir = os.path.abspath(safe_root_dir)
     base_save_dir = normalized_base_save_dir

--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -74,7 +74,13 @@ async def run_deep_research(webui_manager: WebuiManager, components: Dict[Compon
     task_topic = components.get(research_task_comp, "").strip()
     task_id_to_resume = components.get(resume_task_id_comp, "").strip() or None
     max_parallel_agents = int(components.get(parallel_num_comp, 1))
-    base_save_dir = components.get(save_dir_comp, "./tmp/deep_research")
+    base_save_dir = components.get(save_dir_comp, "./tmp/deep_research").strip()
+    safe_root_dir = "./tmp/deep_research"
+    normalized_base_save_dir = os.path.normpath(base_save_dir)
+    if not normalized_base_save_dir.startswith(os.path.abspath(safe_root_dir)):
+        logger.warning(f"Unsafe base_save_dir detected: {base_save_dir}. Using default directory.")
+        normalized_base_save_dir = os.path.abspath(safe_root_dir)
+    base_save_dir = normalized_base_save_dir
     mcp_server_config_str = components.get(mcp_server_config_comp)
     mcp_config = json.loads(mcp_server_config_str) if mcp_server_config_str else None
 

--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -76,7 +76,7 @@ async def run_deep_research(webui_manager: WebuiManager, components: Dict[Compon
     max_parallel_agents = int(components.get(parallel_num_comp, 1))
     base_save_dir = components.get(save_dir_comp, "./tmp/deep_research").strip()
     safe_root_dir = "./tmp/deep_research"
-    normalized_base_save_dir = os.path.normpath(base_save_dir)
+    normalized_base_save_dir = os.path.abspath(os.path.normpath(base_save_dir))
     if os.path.commonpath([normalized_base_save_dir, os.path.abspath(safe_root_dir)]) != os.path.abspath(safe_root_dir):
         logger.warning(f"Unsafe base_save_dir detected: {base_save_dir}. Using default directory.")
         normalized_base_save_dir = os.path.abspath(safe_root_dir)


### PR DESCRIPTION

https://github.com/browser-use/web-ui/blob/886ba8f5354dca96a544ed7b7072fb41e4dcf850/src/agent/deep_research/deep_research_agent.py#L1115-L1115

https://github.com/browser-use/web-ui/blob/886ba8f5354dca96a544ed7b7072fb41e4dcf850/src/agent/deep_research/deep_research_agent.py#L1115-L1115

Fix the issue need to validate the `save_dir` parameter before using it to construct file paths. The best approach is to ensure that the constructed path is contained within a safe root directory. This can be achieved by normalizing the path using `os.path.normpath` and verifying that it starts with the intended root directory.

Steps to implement the fix:
1. Introduce a `safe_root_dir` variable to define the root directory where files can be saved.
2. Normalize the `save_dir` parameter using `os.path.normpath`.
3. Check that the normalized `save_dir` starts with `safe_root_dir`. If it does not, raise an exception or log an error and use a default safe directory instead.


- **Bug Fixes**
 - Normalizes and validates save directory paths in both backend and web UI.
 - Logs a warning and defaults to a safe directory if an unsafe path is detected.

[werkzeug.utils.secure_filename](http://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename)
