### PR TITLE
Fix the ollama api host connect fail problem.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - DEEPSEEK_ENDPOINT=${DEEPSEEK_ENDPOINT:-https://api.deepseek.com}
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
       - OLLAMA_ENDPOINT=${OLLAMA_ENDPOINT:-http://localhost:11434}
-      - OLLAMA_HOST=${OLLAMA_ENDPOINT:-http://localhost:11434}
+      - OLLAMA_HOST=${OLLAMA_HOST:-${OLLAMA_ENDPOINT:-http://localhost:11434}}
       - MISTRAL_ENDPOINT=${MISTRAL_ENDPOINT:-https://api.mistral.ai/v1}
       - MISTRAL_API_KEY=${MISTRAL_API_KEY:-}
       - ALIBABA_ENDPOINT=${ALIBABA_ENDPOINT:-https://dashscope.aliyuncs.com/compatible-mode/v1}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - DEEPSEEK_ENDPOINT=${DEEPSEEK_ENDPOINT:-https://api.deepseek.com}
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
       - OLLAMA_ENDPOINT=${OLLAMA_ENDPOINT:-http://localhost:11434}
+      - OLLAMA_HOST=${OLLAMA_ENDPOINT:-http://localhost:11434}
       - MISTRAL_ENDPOINT=${MISTRAL_ENDPOINT:-https://api.mistral.ai/v1}
       - MISTRAL_API_KEY=${MISTRAL_API_KEY:-}
       - ALIBABA_ENDPOINT=${ALIBABA_ENDPOINT:-https://dashscope.aliyuncs.com/compatible-mode/v1}


### PR DESCRIPTION
I noticed that when someone starts Ollama, there's a problem. It says: 'ERROR... Failed to connect to Ollama. Make sure you're downloaded Ollama, it's running, and you can reach it. You can get it at https://ollama.com/download.'

After I check a resolve issue https://github.com/browser-use/web-ui/issues/595 The reason is environment variable does not contain OLLAMA_HOST

This change adds an environment variable to the docker-compose.yml file.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the OLLAMA_HOST environment variable to docker-compose.yml to fix connection errors when starting Ollama.

<!-- End of auto-generated description by cubic. -->

