### PR TITLE
Add support for DEFAULT_LLM_MODEL environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,8 @@ GROK_API_KEY=
 
 #set default LLM
 DEFAULT_LLM=openai
-
+#set default LLM model
+DEFAULT_LLM_MODEL=gpt-4
 
 # Set to false to disable anonymized telemetry
 ANONYMIZED_TELEMETRY=false

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -71,7 +71,7 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
             llm_model_name = gr.Dropdown(
                 label="LLM Model Name",
                 choices=config.model_names[os.getenv("DEFAULT_LLM", "openai")],
-                value=config.model_names[os.getenv("DEFAULT_LLM", "openai")][0],
+                value=os.getenv("DEFAULT_LLM_MODEL", config.model_names[os.getenv("DEFAULT_LLM", "openai")][0]),
                 interactive=True,
                 allow_custom_value=True,
                 info="Select a model in the dropdown options or directly type a custom model name"


### PR DESCRIPTION
### Summary

This PR introduces support for a new environment variable `DEFAULT_LLM_MODEL` to configure the default LLM model used by the web-ui. This eliminates the need to repeatedly set the model manually.

### Changes Made

* Added support for `DEFAULT_LLM_MODEL` in the executable script.
* Updated code to fetch the model using:

  ```python
  os.getenv("DEFAULT_LLM_MODEL", config.model_names[os.getenv("DEFAULT_LLM", "openai")][0])
  ```
* Ensures a consistent and convenient way to define the default model through environment variables.

---

### How to Test

1. Set the environment variable before running:

   ```bash
   export DEFAULT_LLM_MODEL=gpt-4
   ```
2. Start the web-ui
3. The selected model should default to the value set in `DEFAULT_LLM_MODEL` without requiring manual selection.

---

### Notes

* If `DEFAULT_LLM_MODEL` is not set, fallback logic still uses the default model from `config.model_names` based on the `DEFAULT_LLM` provider or defaults to `"openai"`.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for the DEFAULT_LLM_MODEL environment variable to set the default LLM model in the web UI.

- **New Features**
  - The web UI now uses DEFAULT_LLM_MODEL to pick the default model, so users no longer need to select it manually.
  - If DEFAULT_LLM_MODEL is not set, the app falls back to the existing default logic.

<!-- End of auto-generated description by cubic. -->

