### PR TITLE
Modify the parameters of modelscope

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ OLLAMA_ENDPOINT=http://localhost:11434
 ALIBABA_ENDPOINT=https://dashscope.aliyuncs.com/compatible-mode/v1
 ALIBABA_API_KEY=
 
+MODELSCOPE_ENDPOINT=https://api-inference.modelscope.cn/v1
+MODELSCOPE_API_KEY=
+
 MOONSHOT_ENDPOINT=https://api.moonshot.cn/v1
 MOONSHOT_API_KEY=
 

--- a/src/utils/llm_provider.py
+++ b/src/utils/llm_provider.py
@@ -349,6 +349,7 @@ def get_llm_model(provider: str, **kwargs):
             base_url=base_url,
             model_name=kwargs.get("model_name", "Qwen/QwQ-32B"),
             temperature=kwargs.get("temperature", 0.0),
+            extra_body = {"enable_thinking": False}
         )
     else:
         raise ValueError(f"Unsupported provider: {provider}")


### PR DESCRIPTION
## Introduction
- To ensure normal use of Qwen3 series models, add a parameter of modelscope API.
- And in order to facilitate users to use ModelScope's API, relevant environment parameters are added to the .env.example file.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the enable_thinking parameter to ModelScope API calls for Qwen3 models and updated .env.example with ModelScope environment variables.

- **Dependencies**
  - Added MODELSCOPE_ENDPOINT and MODELSCOPE_API_KEY to .env.example.

<!-- End of auto-generated description by cubic. -->

