### PR TITLE
Fix: "Response" Button Unresponsiveness in Run Agent Tab

### DIFF
--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -632,11 +632,8 @@ async def run_agent_task(
                 last_chat_len = len(webui_manager.bu_chat_history)
                 yield update_dict
                 # Wait until response is submitted or task finishes
-                while (
-                        webui_manager.bu_response_event is not None
-                        and not agent_task.done()
-                ):
-                    await asyncio.sleep(0.2)
+                await webui_manager.bu_response_event.wait()
+
                 # Restore UI after response submitted or if task ended unexpectedly
                 if not agent_task.done():
                     yield {
@@ -1071,7 +1068,7 @@ def create_browser_use_agent_tab(webui_manager: WebuiManager):
 
     # --- Connect Event Handlers using the Wrappers --
     run_button.click(
-        fn=submit_wrapper, inputs=all_managed_components, outputs=run_tab_outputs
+        fn=submit_wrapper, inputs=all_managed_components, outputs=run_tab_outputs, trigger_mode="multiple"
     )
     user_input.submit(
         fn=submit_wrapper, inputs=all_managed_components, outputs=run_tab_outputs


### PR DESCRIPTION
### Summary
This PR resolves an issue where the "Response" button becomes unresponsive in the Run Agent tab of the UI. The issue was caused by using await asyncio.sleep() in a loop, which blocked Gradio from handling other click events when those buttons were tied to the same function.

### Root Cause
Gradio runs on a single-threaded event loop, and using await asyncio.sleep() (even in small intervals) prevents it from processing other user interactions. 

Related Gradio issue: [gradio-app/gradio#6749](https://github.com/gradio-app/gradio/issues/6749)

### Solution
1. Removed Polling with asyncio.sleep
This change allows the coroutine to yield properly, giving control back to Gradio’s event loop and keeping the UI responsive.
2. Enabled trigger_mode="multiple" for the Run Button
This ensures the Run button can be clicked multiple times without blocking subsequent actions.

### Impact
Prevents UI freezing where the "Response" button would not respond to clicks.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where the "Response" button in the Run Agent tab became unresponsive due to blocking event handling.

- **Bug Fixes**
  - Replaced polling with event-based waiting to keep the UI responsive.
  - Enabled trigger_mode="multiple" for the Run button to allow repeated clicks.

<!-- End of auto-generated description by cubic. -->

