### PR TITLE
fix: docker base image fixed to python 3.11 slim bookworn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 # Set platform for multi-arch builds (Docker Buildx will set this)
 ARG TARGETPLATFORM


### PR DESCRIPTION
The `3.11-slim` Docker base image, after defaulting to the new version `3.11-slim-trixie` makes it can't find the  `libgconf-2-4` package.
downgrade to 3.11-slim-bookworm will fix the issue

Fixing this issue: https://github.com/browser-use/web-ui/issues/680
    
Relate commit change: https://github.com/docker-library/python/commit/093598a0190ba9074b899d6a0a21a00c859aac56

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch base image from python:3.11-slim (now trixie) to python:3.11-slim-bookworm to restore libgconf-2-4 availability. Unblocks Docker builds; fixes #680.

<!-- End of auto-generated description by cubic. -->

