### PR TITLE
Fixed docker build issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
       # - ./my_chrome_data:/app/data/chrome_data # Optional: persist browser data
     restart: unless-stopped
-    shm_size: '2gb'
+    shm_size: "2gb"
     cap_add:
       - SYS_ADMIN
     tmpfs:


### PR DESCRIPTION
This fixes the build error I was getting due to libgconf-2-4 not being available in the Debian Trixie base image. I removed that package from the Dockerfile, and the build now works fine — tested on my own and a friend’s machine.

Also added fonts-noto-color-emoji and fonts-unifont to improve rendering in headless browser sessions.

A small formatting tweak in docker-compose.yml too: changed shm_size from single to double quotes just to keep it consistent.

Let me know if anything needs changing.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the Docker build by removing libgconf-2-4 (not available on Debian Trixie) and installing Chromium via Playwright without extra system deps. Added fonts-noto-color-emoji and fonts-unifont for better headless rendering, and standardized shm_size quotes in docker-compose.yml.

<!-- End of auto-generated description by cubic. -->

