### PR TITLE
Comment out langchain-ibm dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ gradio==5.27.0
 json-repair
 langchain-mistralai==0.2.4
 MainContentExtractor==0.0.4
-langchain-ibm==0.3.10
+# langchain-ibm==0.3.10
 langchain_mcp_adapters==0.0.9
 langgraph==0.3.34
 langchain-community


### PR DESCRIPTION
Comment out the langchain-ibm dependency in requirements.txt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commented out langchain-ibm in requirements.txt to disable its installation. This reduces dependencies and avoids setup issues for environments that don’t use IBM integrations.

<sup>Written for commit fe3cb02df72a05324c78ea4905fd92006c24e442. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

